### PR TITLE
fix: add missing space in pc makefile

### DIFF
--- a/Makefile_pc
+++ b/Makefile_pc
@@ -9,7 +9,7 @@ CXX        := g++
 CC         := gcc
 
 # Base compiler flags
-CXXFLAGS_BASE := -std=c++17 -Wall -D__PC__-fexceptions
+CXXFLAGS_BASE := -std=c++17 -Wall -D__PC__ -fexceptions
 CFLAGS_BASE   := -D__PC__
 
 # Debug and Release flags


### PR DESCRIPTION
That's pretty much it. This fixes that really annoying warning when every file is compiled.