### PR TITLE
feat: init 3ds nightly build

### DIFF
--- a/.github/workflows/nightly-3ds.yml
+++ b/.github/workflows/nightly-3ds.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    paths:
+      - Makefile_3ds
+      - source/scratch/**
+      - source/3ds/**
+      - gfx/**
+      - include/**
+  pull_request:
+    paths:
+      - Makefile_3ds
+      - source/scratch/**
+      - source/3ds/**
+      - gfx/**
+      - include/**
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install DevkitPro
+        run: |
+          wget https://apt.devkitpro.org/devkitpro-pub.gpg
+          echo "deb [signed-by=$(pwd)/devkitpro-pub.gpg] https://apt.devkitpro.org stable main" > /etc/apt/sources.list.d/devkitpro.list
+          sudo apt update -y
+          sudo apt install -y devkitpro-pacman
+          echo "DEVKITPRO=/opt/devkitpro" >> $GITHUB_ENV
+          echo "DEVKITARM=/opt/devkitpro/devkitARM" >> $GITHUB_ENV
+          echo "/opt/devkitpro/tools/bin" >> $GITHUB_PATH
+      - name: Install Dependencies
+        run: sudo dkp-pacman -Sy --noconfirm 3ds-dev
+      - name: Build
+        run: make
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Scratch 3DS Nightly
+          path: Scratch-3DS.3dsx

--- a/.github/workflows/nightly-3ds.yml
+++ b/.github/workflows/nightly-3ds.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt install -y devkitpro-pacman
           echo "DEVKITPRO=/opt/devkitpro" >> $GITHUB_ENV
           echo "DEVKITARM=/opt/devkitpro/devkitARM" >> $GITHUB_ENV
-          echo "/opt/devkitpro/tools/bin" >> $GITHUB_PATH
+          echo "$DEVKITPRO/tools/bin" >> $GITHUB_PATH
       - name: Install Dependencies
         run: sudo dkp-pacman -Sy --noconfirm 3ds-dev
       - name: Build


### PR DESCRIPTION
Inspired by https://github.com/NateXS/Scratch-3DS/discussions/34#discussioncomment-13808967.

This will create a nightly build available to logged-in users in the actions tab. It shouldn't require any additional configuration of environment variables.